### PR TITLE
ESA11 fix the detection of user_io core

### DIFF
--- a/fpga.c
+++ b/fpga.c
@@ -155,7 +155,7 @@ RAMFUNC unsigned char ConfigureFpga(char *name)
 
     if(!name)
     //  name = "CORE    BIN";
-		name = "XESM38  BIN";
+		name = "X7A102T BIN";
 
     // open bitstream file
     if (FileOpen(&file, name) == 0)
@@ -209,8 +209,8 @@ RAMFUNC unsigned char ConfigureFpga(char *name)
     }
     while (t < n);
 
-    // disable outputs
-    *AT91C_PIOA_ODR = XILINX_CCLK | XILINX_DIN | XILINX_PROG_B;
+    // return outputs to a state suitable for user_io.c
+    *AT91C_PIOA_SODR = XILINX_CCLK | XILINX_DIN | XILINX_PROG_B;
 
     iprintf("]\r");
     iprintf("FPGA bitstream loaded\r");

--- a/openocd/interface/esa11-ft4232-generic.cfg
+++ b/openocd/interface/esa11-ft4232-generic.cfg
@@ -1,0 +1,8 @@
+#
+# ESA11 onboard FT4232
+#
+
+interface ftdi
+ftdi_device_desc "Quad RS232-HS"
+ftdi_vid_pid 0x0403 0x6011
+ftdi_layout_init 0x3088 0x1f8b


### PR DESCRIPTION
After xilinx bitstream is flashed, the SPI lines are left
in some inconsistent state so user_io module can't work
some extra spi reinitialization and retries are performed
and core is now reliably detected after each bitstream upload
on ESA11 board with xc7a102t
