### PR TITLE
Support extra buttons on USB gamepads/joysticks

### DIFF
--- a/usb/hid.c
+++ b/usb/hid.c
@@ -770,6 +770,9 @@ static void usb_process_iface (usb_hid_iface_info_t *iface,
 				
 				// run even if not changed
 				user_io_digital_joystick(idx, jmap);
+
+				// new API with all extra buttons
+				user_io_digital_joystick_ext(idx, vjoy);
 				
 				// also send analog values
 				user_io_analog_joystick(idx, a[0]-128, a[1]-128);

--- a/user_io.c
+++ b/user_io.c
@@ -338,8 +338,8 @@ void user_io_analog_joystick(unsigned char joystick, char valueX, char valueY) {
 void user_io_digital_joystick(unsigned char joystick, unsigned char map) {
 	uint8_t state = map;
 	// "only" 6 joysticks are supported
-  if(joystick >= 6)
-    return;
+	if(joystick > 5)
+		return;
 	
 		// the physical joysticks (db9 ports at the right device side)
 		// as well as the joystick emulation are renumbered if usb joysticks
@@ -372,7 +372,7 @@ void user_io_digital_joystick(unsigned char joystick, unsigned char map) {
     return;
   }
 
-  //  iprintf("j%d: %x\n", joystick, map);
+	//iprintf("j%d: %x\n", joystick, map);
 
 		
 	// atari ST handles joystick 0 and 1 through the ikbd emulated by the io controller
@@ -388,6 +388,13 @@ void user_io_digital_joystick(unsigned char joystick, unsigned char map) {
     
 }
 
+void user_io_digital_joystick_ext(unsigned char joystick, uint16_t map) {
+	// "only" 6 joysticks are supported
+	if(joystick > 5) return;
+	//iprintf("ext j%d: %x\n", joystick, map);
+	spi_uio_cmd32(UIO_JOYSTICK0_EXT + joystick, 0x0000ffff & map);
+}
+
 static char dig2ana(char min, char max) {
   if(min && !max) return -128;
   if(max && !min) return  127;
@@ -397,6 +404,7 @@ static char dig2ana(char min, char max) {
 void user_io_joystick(unsigned char joystick, unsigned char map) {
   // digital joysticks also send analog signals
   user_io_digital_joystick(joystick, map);
+  user_io_digital_joystick_ext(joystick, map);
   user_io_analog_joystick(joystick, 
 		       dig2ana(map&JOY_LEFT, map&JOY_RIGHT),
 		       dig2ana(map&JOY_UP, map&JOY_DOWN));

--- a/user_io.h
+++ b/user_io.h
@@ -53,6 +53,14 @@
 #define UIO_SET_STATUS2 0x1e  // 32bit status
 #define UIO_GET_KBD_LED 0x1f  // keyboard LEDs control
 
+// extended joystick control (32 bit value)
+#define UIO_JOYSTICK0_EXT   0x60
+#define UIO_JOYSTICK1_EXT   0x61
+#define UIO_JOYSTICK2_EXT   0x62
+#define UIO_JOYSTICK3_EXT   0x63
+#define UIO_JOYSTICK4_EXT   0x64
+#define UIO_JOYSTICK5_EXT   0x65
+
 // codes as used by 8bit (atari 800, zx81) via SS2
 #define UIO_GET_STATUS  0x50
 #define UIO_SECTOR_SND  0x51
@@ -177,6 +185,7 @@ void user_io_mouse(unsigned char b, char x, char y);
 void user_io_kbd(unsigned char m, unsigned char *k, uint8_t priority, unsigned short vid, unsigned short pid);
 char user_io_create_config_name(char *s);
 void user_io_digital_joystick(unsigned char, unsigned char);
+void user_io_digital_joystick_ext(unsigned char, uint16_t);
 void user_io_analog_joystick(unsigned char, char, char);
 char user_io_osd_is_visible();
 void user_io_send_buttons(char);


### PR DESCRIPTION
Not only at the OSD joystick test, but pass extra buttons to the cores, too.