### PR TITLE
Remove deprecated UIO commands

### DIFF
--- a/fat.c
+++ b/fat.c
@@ -39,13 +39,12 @@ JB:
 
 #include <stdio.h>
 #include <string.h>
+#include <ctype.h>
 #include "mmc.h"
 #include "fat.h"
 #include "swap.h"
 #include "usb.h"
 #include "fpga.h"
-
-int tolower(int c);
 
 #define MAX_FS  2
 

--- a/user_io.c
+++ b/user_io.c
@@ -1242,71 +1242,7 @@ void user_io_poll() {
 	mouse_pos[X] = mouse_pos[Y] = 0;
       }
     }
-    
-    // --------------- THE FOLLOWING IS DEPRECATED AND WILL BE REMOVED ------------
-    // ------------------------ USE SD CARD EMULATION INSTEAD ---------------------
 
-    // raw sector io for the atari800 core which include a full
-    // file system driver usually implemented using a second cpu
-    static unsigned long bit8_status = 0;
-    unsigned long status;
-
-    /* read status byte */
-    EnableFpga();
-    SPI(UIO_GET_STATUS);
-    status = SPI(0);
-    status = (status << 8) | SPI(0);
-    status = (status << 8) | SPI(0);
-    status = (status << 8) | SPI(0);
-    DisableFpga();
-
-    if(status != bit8_status) {
-      unsigned long sector = (status>>8)&0xffffff;
-      char buffer[512];
-
-      bit8_status = status;
-      
-      // sector read testing 
-      DISKLED_ON;
-
-      // sector read
-      if(((status & 0xff) == 0xa5) || ((status & 0x3f) == 0x29)) {
-
-	// extended command with 26 bits (for 32GB SDHC)
-	if((status & 0x3f) == 0x29) sector = (status>>6)&0x3ffffff;
-
-	bit8_debugf("SECIO rd %ld", sector);
-
-	if(MMC_Read(sector, buffer)) {
-	  // data is now stored in buffer. send it to fpga
-	  EnableFpga();
-	  SPI(UIO_SECTOR_SND);     // send sector data IO->FPGA
-	  spi_block_write(buffer);
-	  DisableFpga();
-	} else
-	  bit8_debugf("rd %ld fail", sector);
-      }
-
-      // sector write
-      if(((status & 0xff) == 0xa6) || ((status & 0x3f) == 0x2a)) {
-
-	// extended command with 26 bits (for 32GB SDHC)
-	if((status & 0x3f) == 0x2a) sector = (status>>6)&0x3ffffff;
-
-	bit8_debugf("SECIO wr %ld", sector);
-
-	// read sector from FPGA
-	EnableFpga();
-	SPI(UIO_SECTOR_RCV);     // receive sector data FPGA->IO
-	spi_block_read(buffer);
-	DisableFpga();
-
-	if(!MMC_Write(sector, buffer)) 
-	  bit8_debugf("wr %ld fail", sector);
-      }
-
-      DISKLED_OFF;
-    }
   }
 
   if(core_type == CORE_TYPE_ARCHIE) 

--- a/user_io.h
+++ b/user_io.h
@@ -62,9 +62,9 @@
 #define UIO_JOYSTICK5_EXT   0x65
 
 // codes as used by 8bit (atari 800, zx81) via SS2
-#define UIO_GET_STATUS  0x50
-#define UIO_SECTOR_SND  0x51
-#define UIO_SECTOR_RCV  0x52
+#define UIO_GET_STATUS  0x50 // removed
+#define UIO_SECTOR_SND  0x51 // removed
+#define UIO_SECTOR_RCV  0x52 // removed
 #define UIO_FILE_TX     0x53
 #define UIO_FILE_TX_DAT 0x54
 #define UIO_FILE_INDEX  0x55


### PR DESCRIPTION
AFAIK nothing use them, not even the Atari cores, but please review.