### PR TITLE
Debounce virtual joystick keyboard with more than one USB joystick

### DIFF
--- a/usb/hid.c
+++ b/usb/hid.c
@@ -584,6 +584,8 @@ static uint16_t collect_bits(uint8_t *p, uint16_t offset, uint8_t size, bool is_
   return rval;
 }
 
+static usb_hid_iface_info_t *virt_joy_kbd_iface = NULL;
+
 /* processes a single USB interface */
 static void usb_process_iface (usb_hid_iface_info_t *iface, 
 							   uint16_t read, 
@@ -782,7 +784,12 @@ static void usb_process_iface (usb_hid_iface_info_t *iface,
 					handle_5200daptor(iface, buf);
 				
 				// apply keyboard mappings
-				virtual_joystick_keyboard ( vjoy );
+				if ((!virt_joy_kbd_iface) || (virt_joy_kbd_iface == iface)) {
+					bool ret = virtual_joystick_keyboard( vjoy );
+					virt_joy_kbd_iface = NULL;
+					if (ret)
+						virt_joy_kbd_iface = iface;
+				}
 			
 			} // end joystick handling
 		 

--- a/usb/joymapping.c
+++ b/usb/joymapping.c
@@ -406,11 +406,11 @@ void joystick_key_map(char *s) {
 
 /*****************************************************************************/
 
-void virtual_joystick_keyboard ( uint16_t vjoy ) {
+bool virtual_joystick_keyboard ( uint16_t vjoy ) {
 	
   // ignore if globally switched off
   if(mist_cfg.joystick_disable_shortcuts)
-	  return;
+	  return false;
 	
 	// use button combinations as shortcut for certain keys
   uint8_t buf[6] = { 0,0,0,0,0,0 };
@@ -505,4 +505,6 @@ void virtual_joystick_keyboard ( uint16_t vjoy ) {
 	} else {
 		user_io_kbd(0x00, buf, UIO_PRIORITY_GAMEPAD, 0, 0); 
 	}
+
+	return (buf[0] ? true : false);
 }

--- a/usb/joymapping.h
+++ b/usb/joymapping.h
@@ -50,7 +50,7 @@ void joystick_key_map_init(void);
 void joystick_key_map(char *);
 
 // runtime mapping
-void virtual_joystick_keyboard ( uint16_t vjoy );
+bool virtual_joystick_keyboard ( uint16_t vjoy );
 
 /*****************************************************************************/
 


### PR DESCRIPTION
When more than one USB joystick is connected the OSD menu can't be accessed properly because the status of the joysticks are interpreted as consecutive key-press key-release events.