### PR TITLE
minimig-mist: use correct config values for hrtmon (-1 instead of 1)

### DIFF
--- a/config.c
+++ b/config.c
@@ -202,31 +202,31 @@ char UploadActionReplay()
       data = 0xff; // col1l, 1 byte
       SPI((data>>0)&0xff);
       SPIN(); SPIN(); SPIN(); SPIN();
-      data = 0x01; // right, 1 byte
+      data = 0xff; // right, 1 byte
       SPI((data>>0)&0xff);
       SPIN(); SPIN(); SPIN(); SPIN();
       data = 0x00; // keyboard, 1 byte
       SPI((data>>0)&0xff);
       SPIN(); SPIN(); SPIN(); SPIN();
-      data = 0x01; // key, 1 byte
+      data = 0xff; // key, 1 byte
       SPI((data>>0)&0xff);
       SPIN(); SPIN(); SPIN(); SPIN();
-      data = config.enable_ide ? 1 : 0; // ide, 1 byte
+      data = config.enable_ide ? 0xff : 0; // ide, 1 byte
       SPI((data>>0)&0xff);
       SPIN(); SPIN(); SPIN(); SPIN();
-      data = 0x01; // a1200, 1 byte
+      data = 0xff; // a1200, 1 byte
       SPI((data>>0)&0xff);
       SPIN(); SPIN(); SPIN(); SPIN();
-      data = config.chipset&CONFIG_AGA ? 1 : 0; // aga, 1 byte
+      data = config.chipset&CONFIG_AGA ? 0xff : 0; // aga, 1 byte
       SPI((data>>0)&0xff);
       SPIN(); SPIN(); SPIN(); SPIN();
-      data = 0x01; // insert, 1 byte
+      data = 0xff; // insert, 1 byte
       SPI((data>>0)&0xff);
       SPIN(); SPIN(); SPIN(); SPIN();
       data = 0x0f; // delay, 1 byte
       SPI((data>>0)&0xff);
       SPIN(); SPIN(); SPIN(); SPIN();
-      data = 0x01; // lview, 1 byte
+      data = 0xff; // lview, 1 byte
       SPI((data>>0)&0xff);
       SPIN(); SPIN(); SPIN(); SPIN();
       data = 0x00; // cd32, 1 byte
@@ -235,7 +235,7 @@ char UploadActionReplay()
       data = config.chipset&CONFIG_NTSC ? 1 : 0; // screenmode, 1 byte
       SPI((data>>0)&0xff);
       SPIN(); SPIN(); SPIN(); SPIN();
-      data = 1; // novbr, 1 byte
+      data = 0xff; // novbr, 1 byte
       SPI((data>>0)&0xff);
       SPIN(); SPIN(); SPIN(); SPIN();
       data = 0; // entered, 1 byte


### PR DESCRIPTION
According to the comments in HRTmon's src/HRTmonV2.s valid configuration values for some options are -1 and 0:

```
...
config_RM       dc.b 0                  ;28 -1=right-mouse enter on 0=off
config2         dc.b 0                  ;29 no of keyboard to use
config_key      dc.b 0                  ;30 -1= \ key enter on 0=off
config_IDE      dc.b 0                  ;31 -1= IDE harddisk
config_A1200    dc.b 0                  ;32 -1= A1200
config_AGA      dc.b 0                  ;33 -1= AGA
config_insert   dc.b 0                  ;34 -1= insert
config_delay    dc.b 15                 ;35 repeat key delay (default = 15)
config_lview    dc.b 0                  ;36 -1= lview task
config_elsat    dc.b 0                  ;37 -1=elsat.device IDE (CD32)
config_screen   dc.b 0                  ;38 screen mode no 0=PAL,1=NTSC,2=MULTISCAN
config_novbr    dc.b 0                  ;39 0=move vbr, -1=don't move vbr
...
```

The firmware used 1 instead of -1. This caused insert mode toggling with F2 not to work (always on).
