### PR TITLE
minimig-mist: correct OSD menu entry when selecting no at reload kick…

### DIFF
--- a/menu.c
+++ b/menu.c
@@ -3327,7 +3327,7 @@ void HandleUI(void)
 					else if (menusub == 1)
 					{
 							menustate = MENU_SETTINGS_MEMORY1;
-							menusub = 2;
+							menusub = 3;
 					}
 				}
 


### PR DESCRIPTION
…start

Jump back to Memory->ROM not Memory->Fast when selecting 'No' at 'Reload Kickstart?'.