### PR TITLE
Fix scrolling of long directory names and file names in OSD

### DIFF
--- a/menu.c
+++ b/menu.c
@@ -632,7 +632,7 @@ void HandleUI(void)
 			++helpstate;
 		}
 		else
-			ScrollText(7,helptext,0,0,0);
+			ScrollText(7,helptext,0,0,0,0);
 	}
 
 	// Standardised menu up/down.
@@ -1159,7 +1159,7 @@ void HandleUI(void)
 			OsdDrawLogo(3,3,1);
 			OsdDrawLogo(4,4,1);
 			OsdDrawLogo(6,6,1);
-			ScrollText(5,"                                 MiST by Till Harbaum, based on Minimig by Dennis van Weeren and other projects. MiST hardware and software is distributed under the terms of the GNU General Public License version 3. MiST FPGA cores are the work of their respective authors under individual licensing.", 0, 0, 0);			
+			ScrollText(5,"                                 MiST by Till Harbaum, based on Minimig by Dennis van Weeren and other projects. MiST hardware and software is distributed under the terms of the GNU General Public License version 3. MiST FPGA cores are the work of their respective authors under individual licensing.", 0, 0, 0, 0);			
 			// menu key closes menu
 			if (menu) {
 				menustate = MENU_8BIT_SYSTEM1;
@@ -3609,9 +3609,9 @@ void ScrollLongName(void)
 
         max_len = 30; // number of file name characters to display (one more required for scrolling)
         if (DirEntry[k].Attributes & ATTR_DIRECTORY)
-            max_len = 25; // number of directory name characters to display
+            max_len = 23; // number of directory name characters to display
 
-		ScrollText(iSelectedEntry,DirEntryLFN[k],len,max_len,1);
+		ScrollText(iSelectedEntry,DirEntryLFN[k],len,max_len,1,2);
     }
 }
 

--- a/osd.c
+++ b/osd.c
@@ -676,7 +676,7 @@ unsigned char GetASCIIKey(unsigned char keycode)
 }
 
 
-void ScrollText(char n,const char *str, int len,int max_len,unsigned char invert)
+void ScrollText(char n, const char *str, int len, int max_len, unsigned char invert, int len_offset)
 {
 // this function is called periodically when a string longer than the window is displayed.
 
@@ -696,7 +696,7 @@ void ScrollText(char n,const char *str, int len,int max_len,unsigned char invert
 		if(!len)
 	        len = strlen(str); // get name length
 
-        if (len > max_len) // scroll name if longer than display size
+        if (len + len_offset > max_len) // scroll name if longer than display size
         {
             if (scroll_offset >= (len + BLANKSPACE) << 3) // reset scroll position if it exceeds predefined maximum
                 scroll_offset = 0;

--- a/osd.h
+++ b/osd.h
@@ -127,7 +127,7 @@ void OSD_PrintText(unsigned char line, char *text, unsigned long start, unsigned
 void OsdWriteDoubleSize(unsigned char n, char *s, unsigned char pass);
 //void OsdDrawLogo(unsigned char n, char row);
 void OsdDrawLogo(unsigned char n, char row,char superimpose);
-void ScrollText(char n,const char *str, int len, int max_len,unsigned char invert);
+void ScrollText(char n, const char *str, int len, int max_len, unsigned char invert, int len_offset);
 void ScrollReset();
 void StarsInit();
 void StarsUpdate();


### PR DESCRIPTION
* number of directory name characters to display when scrolling was two chars too wide, ` <DIR>` was partly overwritten.
* added parameter len_offset to ScrollText(). This is required for directory names and file names because they are shifted on OSD display and the len comparison didn't work in some cases:
  * directory names were cut at 21 chars but scrolled only if the directory name was larger than 25 chars.
  * file names were cut at 28 chars but scrolled only if the file name was larger than 30 chars