### PR TITLE
gcc 9 warnings fixes

### DIFF
--- a/data_io.c
+++ b/data_io.c
@@ -151,7 +151,7 @@ void data_io_rom_upload(char *rname, char mode) {
   user_io_change_into_core_dir();
 
   strcpy(s, "        ROM");
-  strncpy(s, rname, strlen(rname));
+  strncpy(s, rname, strlen(rname) < 8 ? strlen(rname) : 8);
   iprintf("rom upload '%s' %d\n", s, sizeof(f));
 
   if (FileOpenDir(&f, s, iCurrentDirectory)) {

--- a/hdd_internal.h
+++ b/hdd_internal.h
@@ -6,7 +6,7 @@
 // on blocks 0 and 1.  All other blocks within the first cylinder will be translated into the hardfile
 
 struct RigidDiskBlock {
-    unsigned long   rdb_ID;	// "RDSK"
+    unsigned long   rdb_ID __attribute__ ((aligned(4)));	// "RDSK"
     unsigned long   rdb_Summedlongs; // 0x40
     long			rdb_ChkSum;	// Sum to zero
     unsigned long   rdb_HostID;	// 0x07
@@ -70,7 +70,7 @@ struct DosEnvec {
 
 
 struct PartitionBlock {
-    unsigned long   pb_ID;		// "PART"
+    unsigned long   pb_ID __attribute__ ((aligned(4)));		// "PART"
     unsigned long   pb_Summedlongs;	// 0x40
     long    pb_ChkSum;		// Sum to zero
     unsigned long   pb_HostID;		// 0x07


### PR DESCRIPTION
Fixes for gcc 9 compiler warnings.

```
hdd.c: In function 'FakeRDB':
hdd.c:124:7: warning: converting a packed 'struct RigidDiskBlock' pointer (alignment 1) to a 'long unsigned int' pointer (alignment 4) may result in an unaligned pointer value [-Waddress-of-packed-member]
  124 |       unsigned long *p = (unsigned long*)rdb;
      |       ^~~~~~~~
In file included from hdd.c:36:
hdd_internal.h:8:8: note: defined here
    8 | struct RigidDiskBlock {
      |        ^~~~~~~~~~~~~~
hdd.c:126:7: warning: converting a packed 'struct RigidDiskBlock' pointer (alignment 1) to a 'long unsigned int' pointer (alignment 4) may result in an unaligned pointer value [-Waddress-of-packed-member]
  126 |       RDBChecksum((unsigned long *)rdb);
      |       ^~~~~~~~~~~
In file included from hdd.c:36:
hdd_internal.h:8:8: note: defined here
    8 | struct RigidDiskBlock {
      |        ^~~~~~~~~~~~~~
hdd.c:154:7: warning: converting a packed 'struct PartitionBlock' pointer (alignment 1) to a 'long unsigned int' pointer (alignment 4) may result in an unaligned pointer value [-Waddress-of-packed-member]
  154 |       RDBChecksum((unsigned long *)pb);
      |       ^~~~~~~~~~~
In file included from hdd.c:36:
hdd_internal.h:72:8: note: defined here
   72 | struct PartitionBlock {
      |        ^~~~~~~~~~~~~~
hdd.c:156:7: warning: converting a packed 'struct PartitionBlock' pointer (alignment 1) to a 'long unsigned int' pointer (alignment 4) may result in an unaligned pointer value [-Waddress-of-packed-member]
  156 |       unsigned long *p = (unsigned long*)pb;
      |       ^~~~~~~~
In file included from hdd.c:36:
hdd_internal.h:72:8: note: defined here
   72 | struct PartitionBlock {
      |        ^~~~~~~~~~~~~~
```

```
data_io.c: In function 'data_io_rom_upload':
data_io.c:154:3: warning: 'strncpy' specified bound depends on the length of the source argument [-Wstringop-overflow=]
  154 |   strncpy(s, rname, strlen(rname));
      |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
