### PR TITLE
ini_parser: add tilde as special char

### DIFF
--- a/ini_parser.c
+++ b/ini_parser.c
@@ -33,7 +33,7 @@
 #define CHAR_IS_ALPHA_UPPER(c)  (((c) >= 'A') && ((c) <= 'Z'))
 #define CHAR_IS_ALPHA(c)        (CHAR_IS_ALPHA_LOWER(c) || CHAR_IS_ALPHA_UPPER(c))
 #define CHAR_IS_ALPHANUM(c)     (CHAR_IS_ALPHA_LOWER(c) || CHAR_IS_ALPHA_UPPER(c) || CHAR_IS_NUM(c))
-#define CHAR_IS_SPECIAL(c)      (((c) == '[') || ((c) == ']') || ((c) == '-') || ((c) == '_') || ((c) == ',') || ((c) == '='))
+#define CHAR_IS_SPECIAL(c)      (((c) == '[') || ((c) == ']') || ((c) == '-') || ((c) == '_') || ((c) == ',') || ((c) == '=') || ((c) == '~'))
 #define CHAR_IS_VALID(c)        (CHAR_IS_ALPHANUM(c) || CHAR_IS_SPECIAL(c))
 #define CHAR_IS_WHITESPACE(c)   (((c) == ' ') || ((c) == '\t') || ((c) == '\r') || ((c) == '\n'))
 #define CHAR_IS_SPACE(c)        (((c) == ' ') || ((c) == '\t'))


### PR DESCRIPTION
Allow tilde in mist.ini.

I have the following files for the C64 core:

```
C64GS    ROM     16384 2020-04-11  19:52  c64gs.rom
C64      RBF    419481 2020-04-30  16:23  c64.rbf
C64GS    ARC        31 2020-04-11  19:52 
C64_JI~1 ROM     32768 2019-02-04  22:31  c64_jiffydos.rom
C64_OR~1 ROM     32768 2020-04-26  10:55  c64_original.rom
```

This change allows to use the short name of a file with long name in mist.ini e.g. for the `rom=` option.

```
[c64]
...
rom=C64_JI~1
```