### PR TITLE
Add 'joystick_db9_fixed_index' option to mist.ini to prefer DB9 joyst…

### DIFF
--- a/mist_cfg.c
+++ b/mist_cfg.c
@@ -51,6 +51,7 @@ mist_cfg_t mist_cfg = {
   .joystick_ignore_osd = 0,
   .joystick_disable_shortcuts = 0,
   .joystick0_prefer_db9 = 0,
+  .joystick_db9_fixed_index = 0,
   .joystick_emu_fixed_index = 0,
   .key_menu_as_rgui = 0,
   .keyrah_mode = 0,
@@ -91,6 +92,7 @@ const ini_var_t mist_ini_vars[] = {
   {"JOYSTICK_DISABLE_SHORTCUTS", (void*)(&(mist_cfg.joystick_disable_shortcuts)), UINT8, 0, 1, 1},
   {"JOYSTICK_IGNORE_OSD", (void*)(&(mist_cfg.joystick_ignore_osd)), UINT8, 0, 1, 1},
   {"JOYSTICK0_PREFER_DB9", (void*)(&(mist_cfg.joystick0_prefer_db9)), UINT8, 0, 1, 1},
+  {"JOYSTICK_DB9_FIXED_INDEX", (void*)(&(mist_cfg.joystick_db9_fixed_index)), UINT8, 0, 1, 1},
   {"JOYSTICK_EMU_FIXED_INDEX", (void*)(&(mist_cfg.joystick_emu_fixed_index)), UINT8, 0, 1, 1},
   {"KEY_MENU_AS_RGUI", (void*)(&(mist_cfg.key_menu_as_rgui)), UINT8, 0, 1, 1},
 #ifndef INI_PARSER_TEST

--- a/mist_cfg.h
+++ b/mist_cfg.h
@@ -22,6 +22,7 @@ typedef struct {
   uint8_t joystick_ignore_osd;
   uint8_t joystick_disable_shortcuts;
   uint8_t joystick0_prefer_db9;
+  uint8_t joystick_db9_fixed_index;
   uint8_t joystick_emu_fixed_index;
   uint8_t key_menu_as_rgui;
   uint8_t reset_combo;

--- a/user_io.c
+++ b/user_io.c
@@ -547,6 +547,10 @@ static uint8_t joystick_renumber(uint8_t j) {
   // no usb sticks present: no changes are being made
   if(!usb_sticks) return j;
 
+  // Keep DB9 joysticks as joystick 0 and joystick 1
+  // USB joysticks will be 2,3,...
+  if(mist_cfg.joystick_db9_fixed_index) return j;
+
 	if(j == 0) {
 		// if usb joysticks are present, then physical joystick 0 (mouse port)
 		// becomes becomes 2,3,...
@@ -896,8 +900,9 @@ void user_io_poll() {
     if(!(joy0_state & JOY0_BTN1))  joy_map |= JOY_BTN1;
     if(!(joy0_state & JOY0_BTN2))  joy_map |= JOY_BTN2;
 
-    user_io_joystick(joystick_renumber(0), joy_map);
-    StateJoySet(joy_map, hid_get_joysticks()); // send to OSD
+    uint8_t idx = joystick_renumber(0);
+    user_io_joystick(idx, joy_map);
+    StateJoySet(joy_map, idx); // send to OSD
   }
   
   static int joy1_state = JOY1;
@@ -912,8 +917,9 @@ void user_io_poll() {
     if(!(joy1_state & JOY1_BTN1))  joy_map |= JOY_BTN1;
     if(!(joy1_state & JOY1_BTN2))  joy_map |= JOY_BTN2;
 
-    user_io_joystick(joystick_renumber(1), joy_map);
-    StateJoySet(joy_map, hid_get_joysticks()+1); // send to OSD
+    uint8_t idx = joystick_renumber(1);
+    user_io_joystick(idx, joy_map);
+    StateJoySet(joy_map, idx); // send to OSD
   }
 
   user_io_send_buttons(0);


### PR DESCRIPTION
This PR adds a new option 'joystick_db9_fixed_index' to mist.init.
It allows to always prefer DB9 joystick, even when USB joysticks are connected.
This is useful on computer cores (c64, atarist, minimig ...)

Setting this option in per-core sections of mist.ini allow to use DB9 joysticks on selected computer cores, while using USB joystick on all other cores (megadrive, snes ...)

https://github.com/mist-devel/mist-board/issues/150