### PR TITLE
Fix long-standing ADF write corruption bug

### DIFF
--- a/fdd.c
+++ b/fdd.c
@@ -598,7 +598,8 @@ void WriteTrack(adfTYPE *drive)
     file.sector = drive->track * 11;
     sector = 0;
 
-    drive->track_prev = drive->track + 1; // just to force next read from the start of current track
+//    drive->track_prev = drive->track + 1; // This causes a read that directly follows a write to the previous track to return bad data.
+    drive->track_prev = -1; // just to force next read from the start of current track
 
     while (FindSync(drive))
     {


### PR DESCRIPTION
There's been a long-standing bug in ADF writes where copying files to an ADF using Workbench would frequently result in a corrupted filesystem.  I've traced it to a single line of code in fdd.c which is intended to prevent bad data when reading back a track that's just been written to - but instead causes bad data when reading the following track!  Setting prev_track to a value that will never match a requested track fixes the issue.