### PR TITLE
Always put parent directory entry '..' at top

### DIFF
--- a/fat.c
+++ b/fat.c
@@ -413,11 +413,15 @@ int CompareDirEntries(DIRENTRY *pDirEntry1, char *pLFN1, DIRENTRY *pDirEntry2, c
     int len;
     int rc;
 
-    if ((pDirEntry1->Attributes & ATTR_DIRECTORY) && !(pDirEntry2->Attributes & ATTR_DIRECTORY)) // directories first
-       return -1;
+    if ((pDirEntry2->Attributes & ATTR_DIRECTORY)
+        && !(pDirEntry1->Attributes & ATTR_DIRECTORY) // directories first
+        || (pDirEntry2->Name[0] == '.' && pDirEntry2->Name[1] == '.')) // parent directory entry at top
+            return 1;
 
-    if (!(pDirEntry1->Attributes & ATTR_DIRECTORY) && (pDirEntry2->Attributes & ATTR_DIRECTORY)) // directories first
-       return 1;
+    if ((pDirEntry1->Attributes & ATTR_DIRECTORY)
+        && !(pDirEntry2->Attributes & ATTR_DIRECTORY) // directories first
+        || (pDirEntry1->Name[0] == '.' && pDirEntry1->Name[1] == '.')) // parent directory entry at top
+            return -1;
 
     len = 260;
     if (*pLFN1)


### PR DESCRIPTION
I have a games directory with several subdirectories. To force directories with games collections at the top of the directory list I put a char below '0' as first char in the name (the number sign '#').

The sorted directory is displayed as

```
#collectionA       <DIR>
#collectionB       <DIR>
..                 <DIR>
0                  <DIR>
1                  <DIR>
2                  <DIR>
A                  <DIR>
B                  <DIR>
C                  <DIR>
```

With this commit the directory entry '..' for the parent directory is always put at the top of the list which makes it easier to navigate, e.g. the Home key always gets you to the entry of the parent directory.
