### PR TITLE
Minimig mod keys

### DIFF
--- a/mist_cfg.c
+++ b/mist_cfg.c
@@ -60,7 +60,8 @@ mist_cfg_t mist_cfg = {
   .reset_combo = 0,
   .ypbpr = 0,
   .keep_video_mode = 0,
-  .led_animation = 0
+  .led_animation = 0,
+  .amiga_mod_keys = 0
 };
 
 minimig_cfg_t minimig_cfg = {
@@ -107,6 +108,7 @@ const ini_var_t mist_ini_vars[] = {
   {"JOY_KEY_MAP", (void*)joystick_key_map, CUSTOM_HANDLER, 0, 0, 1},
 #endif
   {"ROM", (void*)ini_rom_upload, CUSTOM_HANDLER, 0, 0, 1},
+  {"AMIGA_MOD_KEYS", (void*)(&(mist_cfg.amiga_mod_keys)), UINT8, 0, 1, 1},
   // [MINIMIG_CONFIG]
   {"KICK1X_MEMORY_DETECTION_PATCH", (void*)(&(minimig_cfg.kick1x_memory_detection_patch)), UINT8, 0, 1, 2},
   {"CLOCK_FREQ", (void*)(&(minimig_cfg.clock_freq)), UINT8, 0, 2, 2},

--- a/mist_cfg.h
+++ b/mist_cfg.h
@@ -31,6 +31,7 @@ typedef struct {
   uint8_t keep_video_mode;
   uint8_t led_animation;
   uint8_t sdram64;
+  uint8_t amiga_mod_keys;
 } mist_cfg_t;
 
 

--- a/user_io.c
+++ b/user_io.c
@@ -1800,6 +1800,32 @@ void user_io_kbd(unsigned char m, unsigned char *k, uint8_t priority, unsigned s
 
 	if(keyrah) keyrah_trans(&m, k);
 
+	if(mist_cfg.amiga_mod_keys) {
+		//  bit  0     1      2    3    4     5      6    7
+		//  key  LCTRL LSHIFT LALT LGUI RCTRL RSHIFT RALT RGUI
+		//       1     2      4    8    10    20     40   80
+		unsigned char m_in = m;
+		// swap RALT/RGUI & LALT/LGUI
+		m = ((m & 0x40) << 1) | ((m & 0x80) >> 1) | m & 0x20 | m & 0x10 | ((m & 0x8) >> 1) | ((m & 0x4) << 1) | m & 0x2;
+		// swap CAPSLOCK/LCTRL
+		for(char i=0;i<6;i++) {
+			if(k[i] == 0x39) {
+				m |= 0x1;
+				k[i] = 0;
+			}
+			if(m_in & 0x1) {
+				if(i<5) {
+					if(k[i] == 0) {
+						k[i] = 0x39;
+						m_in &= ~0x1;
+					}
+				} else {
+					k[i] = 0x39;
+				}
+			}
+		}
+	}
+
 	unsigned short reset_m = m;
 	for(char i=0;i<6;i++) if(k[i] == 0x4c) reset_m |= 0x100;
 	check_reset(reset_m, KEYRAH_ID ? 1 : mist_cfg.reset_combo);


### PR DESCRIPTION
amiga_mod_keys option for mist.ini to swap left ctrl and capslock and swap alts and windows keys as requested here:
* https://www.atari-forum.com/viewtopic.php?p=407256#p407256
* https://www.atari-forum.com/viewtopic.php?p=410306#p410306

Confirmed working here: https://www.atari-forum.com/viewtopic.php?p=410766#p410766

And requested to include in the firmware here: https://www.atari-forum.com/viewtopic.php?p=415535#p415535
