### PR TITLE
hdd.h: add missing parameter in declaration of chs2lba()

### DIFF
--- a/hdd.h
+++ b/hdd.h
@@ -73,7 +73,7 @@ extern hdfTYPE hdf[2];
 
 // functions
 void IdentifyDevice(unsigned short *pBuffer, unsigned char unit);
-unsigned long chs2lba(unsigned short cylinder, unsigned char head, unsigned short sector, unsigned char unit);
+unsigned long chs2lba(unsigned short cylinder, unsigned char head, unsigned short sector, unsigned char unit, char lbamode);
 void WriteTaskFile(unsigned char error, unsigned char sector_count, unsigned char sector_number, unsigned char cylinder_low, unsigned char cylinder_high, unsigned char drive_head);
 void WriteStatus(unsigned char status);
 void HandleHDD(unsigned char c1, unsigned char c2);


### PR DESCRIPTION
Fix for
```
hdd.c:238:15: error: conflicting types for 'chs2lba'; have 'long unsigned int(short unsigned int,  unsigned char,  short unsigned int,  unsigned char,  char)'
  238 | unsigned long chs2lba(unsigned short cylinder, unsigned char head, unsigned short sector, unsigned char unit, char lbamode)
      |               ^~~~~~~
In file included from hdd.c:37:
hdd.h:76:15: note: previous declaration of 'chs2lba' with type 'long unsigned int(short unsigned int,  unsigned char,  short unsigned int,  unsigned char)'
   76 | unsigned long chs2lba(unsigned short cylinder, unsigned char head, unsigned short sector, unsigned char unit);
      |               ^~~~~~~
make: *** [Makefile:82: hdd.o] Error 1
```