### PR TITLE
Fix _strnicmp to not miss directory entries

### DIFF
--- a/utils.c
+++ b/utils.c
@@ -2,6 +2,7 @@
 #include <stddef.h>
 #include <stdint.h>
 #include <ctype.h>
+#include <string.h>
 #include "utils.h"
 #include "attrs.h"
 
@@ -15,17 +16,23 @@ unsigned char bcd2bin(unsigned char in) {
 
 FAST int _strnicmp(const char *s1, const char *s2, size_t n)
 {
+  int s1l, s2l;
   char c1, c2;
   int v;
 
-  do
-    {
+  s1l = strlen(s1);
+  s2l = strlen(s2);
+
+  do {
     c1 = *s1++;
     c2 = *s2++;
     if (!c1) break;
     v = (unsigned int)tolower(c1) - (unsigned int)tolower(c2);
-    }
-  while (v == 0 && --n > 0);
+  } while (v == 0 && --n > 0);
+
+  if ((v==0) && n && (s1l != s2l)) {
+    return((s1l > s2l) ? 1 : -1);
+  }
 
   return v;
 }


### PR DESCRIPTION
I have a FAT32 formatted SD card with a directory with cores from Jotego and correct system flags:
```
root@dev64:/media/sd/Arcade/Jotego# fatattr *
  s d    1942
  s d    1943
  s d    Bionic Commando
  s d    Black Tiger
  s d    Bubble Bobble
  s d    Combat School
  s d    Commando
  s d    Contra
  s d    CPS1
  s d    CPS15
  s d    CPS2
  s d    Double Dragon
  s d    Double Dragon II
  s d    F1 Dream
  s d    Ghosts 'n Goblins
  s d    Gun Smoke
r    a   jtsdram48_20210108.rbf
r    a   jtsdram96_20210108.rbf
  s d    Labyrinth Runner
  s d    Pirate Ship Higemaru
  s d    Section Z
  s d    Side Arms
  s d    Speed Rumbler
  s d    Street Fighter
  s d    System 16
  s d    Tiger Road
  s d    Trojan
  s d    Vulgus
```

Directories ```CPS1``` and ```Double Dragon``` are not visible in OSD with the latest firmware (210618) because of incomplete file/directory name comparison in function _strnicmp().

This worked with old firmware (<210525) before the change to FatFS/exFAT.

Another option would be to replace function _strnicmp() with strncasecmp(). This even reduces the size of the firmware a bit but strncasecmp() is probably slower.
