### PR TITLE
Handle read-only floppy disk images for mist core

### DIFF
--- a/tos.c
+++ b/tos.c
@@ -1221,7 +1221,10 @@ void tos_insert_disk(char i, const unsigned char *name) {
   if(!name || !name[0]) return;
 
   if (f_open(&fdd_image[i].file, name, FA_READ | FA_WRITE) != FR_OK)
-    return;
+    if (f_open(&fdd_image[i].file, name, FA_READ) == FR_OK)
+      mist_set_control(config.system_ctrl | wp_bit);
+    else
+      return;
 
   strncpy(fdd_image[i].name, name, sizeof(fdd_image[i].name));
   fdd_image[i].name[sizeof(fdd_image[i].name)-1] = 0;


### PR DESCRIPTION
Yet another regression after the switch to exFAT file system.