### PR TITLE
minimig-menu.c: fix OSD menu state when loading config

### DIFF
--- a/minimig-menu.c
+++ b/minimig-menu.c
@@ -663,10 +663,11 @@ static char GetMenuItem_Minimig(uint8_t idx, char action, menu_item_t *item) {
 				case 23:
 				case 24:
 				case 25:
+					CloseMenu();
+					ResetMenu();
 					OsdDisable();
 					SetConfigurationFilename(idx-21);
 					LoadConfiguration(NULL, 0);
-					ResetMenu();
 					break;
 
 				// Page 4 - Save configuration


### PR DESCRIPTION
This fixes a regression introduced with the restructured menu engine in firmware 211207.

See https://www.atari-forum.com/viewtopic.php?p=427729#p427729