### PR TITLE
usb.c: add 8 bytes device descriptor read before and after set address

### DIFF
--- a/usb/usb.c
+++ b/usb/usb.c
@@ -382,6 +382,9 @@ uint8_t usb_configure(uint8_t parent, uint8_t port, bool lowspeed) {
 		d->ep0.epAttribs  = 0;
 		d->ep0.bmNakPower = USB_NAK_MAX_POWER;
 
+		if(rcode = usb_get_dev_descr( d, 8, &dev_desc ))
+			return rcode;
+
 		// Assign new address to the device
 		// (address is simply the number of the free slot + 1)
 		iprintf("Setting addr %x\n", i+1);
@@ -390,6 +393,9 @@ uint8_t usb_configure(uint8_t parent, uint8_t port, bool lowspeed) {
 			iprintf("failed to assign address (rcode=%d)", rcode);
 			return rcode;
 		}
+
+		if(rcode = usb_get_dev_descr( d, 8, &dev_desc ))
+			return rcode;
 
 		// --- enumerate device ---
 		if(rcode = usb_get_dev_descr( d, sizeof(usb_device_descriptor_t), &dev_desc ))


### PR DESCRIPTION
Fixes recognition of Speedlink Competition Pro USB joystick