### PR TITLE
Switch boot from SD/USB with User Button

### DIFF
--- a/hw/AT91SAM/hardware.c
+++ b/hw/AT91SAM/hardware.c
@@ -372,6 +372,7 @@ void InitADC(void) {
   PollOneADC();
   PollOneADC();
   PollOneADC();
+  PollOneADC();
 }
 
 // poll one adc channel every 25ms

--- a/hw/AT91SAM/hardware.h
+++ b/hw/AT91SAM/hardware.h
@@ -94,6 +94,9 @@
 #define VIDEO_SD_DISABLE_VAR (*(uint8_t*)0x0020FF15)
 #define VIDEO_YPBPR_VAR      (*(uint8_t*)0x0020FF16)
 
+#define USB_BOOT_VALUE       0x8007F007
+#define USB_BOOT_VAR         (*(int*)0x0020FF18)
+
 #define SECTOR_BUFFER_SIZE   4096
 
 char mmc_inserted(void);

--- a/usb/hub.c
+++ b/usb/hub.c
@@ -33,7 +33,6 @@ static uint8_t usb_hub_get_port_status(usb_device_t *dev, uint8_t port, uint16_t
 }
 
 static uint8_t usb_hub_parse_conf(usb_device_t *dev, uint8_t conf, uint16_t len, ep_t *pep) {
-  usb_storage_info_t *info = &(dev->storage_info);
   uint8_t rcode;
   bool is_good_interface = false;
 

--- a/usb/storage.c
+++ b/usb/storage.c
@@ -2,6 +2,7 @@
 // storage.c
 //
 
+#ifdef USB_STORAGE
 #include <stdio.h>
 #include <string.h>
 
@@ -497,3 +498,4 @@ unsigned int usb_host_storage_capacity() {
 
 const usb_device_class_config_t usb_storage_class = {
   usb_storage_init, usb_storage_release, usb_storage_poll };  
+#endif

--- a/user_io.c
+++ b/user_io.c
@@ -150,8 +150,6 @@ void user_io_init() {
 	// mark remap table as unused
 	memset(key_remap_table, 0, sizeof(key_remap_table));
 
-	InitADC();
-
 	if(MenuButton()) DEBUG_MODE_VAR = DEBUG_MODE ? 0 : DEBUG_MODE_VALUE;
 	iprintf("debug_mode = %d\n", DEBUG_MODE);
 


### PR DESCRIPTION
The changes in this PR allow to switch the boot order of SD/USB across resets with the User Button:

* SD, fall back to USB (standard)
* USB, fall back to SD

This is convenient when you want to test something on an USB stick without ejecting the SD card.
Connect USB stick, press and hold User Button, power on MiST -> USB stick is the primary device.

It's always possible to switch between the two priority settings by pressing and holding User Button and then reset MiST.
