### PR TITLE
Several improvements for USB joysticks support

### DIFF
--- a/osd.c
+++ b/osd.c
@@ -40,6 +40,7 @@ This is the Minimig OSD (on-screen-display) handler.
 #include "spi.h"
 
 #include "logo.h"
+#include "state.h"
 #include "user_io.h"
 
 extern unsigned char charfont[128][8];
@@ -590,7 +591,7 @@ unsigned char OsdGetCtrl(void)
     if(!c) {
       static unsigned char last_but = 0;
         if(!disable_menu) {
-          unsigned char but = CheckButton();
+          unsigned char but = CheckButton() || StateJoyGetMenuAny();
           if(!but && last_but) c = KEY_MENU;
           last_but = but;
         } else {

--- a/state.c
+++ b/state.c
@@ -40,7 +40,8 @@ static mist_joystick_t mist_joystick_temp;
 	.right=0, \
 	.usb_state=0, \
 	.usb_state_extra=0, \
-	.analogue={0,0,0,0} \
+	.analogue={0,0,0,0}, \
+	.menu_button=0, \
 	}
 
 /* latest joystick state */
@@ -64,6 +65,7 @@ void StateReset() {
 		StateJoySetExtra(0, idx);
 		StateJoySetRight(0, idx);
 		StateJoySetAnalogue(0, 0, 0, 0, idx);
+		StateJoySetMenu(0, idx);
 		StateUsbIdSet(0, 0, 0, idx);
 		StateUsbJoySet(0, 0, idx);
 	}
@@ -91,6 +93,11 @@ void StateJoySetAnalogue(uint8_t lx, uint8_t ly, uint8_t rx, uint8_t ry, uint8_t
 	mist_joysticks[joy_num].analogue[2] = rx;
 	mist_joysticks[joy_num].analogue[3] = ry;
 }
+static uint8_t mist_joystick_menu;
+void StateJoySetMenu(uint8_t c, uint8_t joy_num) {
+	if (joy_num > 5) return;
+	mist_joysticks[joy_num].menu_button = c;
+}
 
 uint8_t StateJoyGet(uint8_t joy_num) {
   return (joy_num < 6) ? mist_joysticks[joy_num].state : 0;
@@ -104,6 +111,18 @@ uint8_t StateJoyGetRight(uint8_t joy_num) {
 uint8_t StateJoyGetAnalogue(uint8_t idx, uint8_t joy_num) {
 	return (joy_num < 6 && idx < 4) ? mist_joysticks[joy_num].analogue[idx] : 0;
 }
+uint8_t StateJoyGetMenu(uint8_t joy_num) {
+	return (joy_num < 6) ? mist_joysticks[joy_num].menu_button : 0;
+}
+uint8_t StateJoyGetMenuAny() {
+	uint8_t joy_num;
+	for(joy_num=0; joy_num<6; joy_num++) {
+		if (mist_joysticks[joy_num].menu_button)
+			return mist_joysticks[joy_num].menu_button;
+	}
+	return 0;
+}
+
 
 
 void StateUsbJoySet(uint8_t usbjoy, uint8_t usbextra, uint8_t joy_num) {
@@ -191,4 +210,3 @@ void StateKeyboardPressed(uint8_t *keycodes) {
 	for(i=0; i<6; i++) 
 		keycodes[i]=key_pressed[i];
 }
-

--- a/state.h
+++ b/state.h
@@ -17,6 +17,7 @@ typedef struct {
 	uint8_t  usb_state;				// raw USB state of direction and buttons
 	uint8_t  usb_state_extra; // raw USB state of 8 more buttons
 	uint8_t  analogue[4];
+	uint8_t  menu_button;
 	
 } mist_joystick_t;
 
@@ -52,6 +53,11 @@ uint8_t StateJoyGetAnalogue(uint8_t idx, uint8_t joy_num);
 uint8_t StateNumJoysticks();
 void StateNumJoysticksSet(uint8_t num);
 
+void StateJoySetMenu(uint8_t c, uint8_t joy_num);
+uint8_t StateJoyGetMenu(uint8_t joy_num);
+uint8_t StateJoyGetMenuAny();
+
+
 // keyboard status
 void StateKeyboardSet( uint8_t modifier, uint8_t* pressed, uint16_t* pressed_ps2); //get usb and ps2 codes
 uint8_t StateKeyboardModifiers();
@@ -59,4 +65,3 @@ void StateKeyboardPressed(uint8_t *pressed);
 void StateKeyboardPressedPS2(uint16_t *keycodes);
 
 #endif
-

--- a/usb/hid.c
+++ b/usb/hid.c
@@ -893,7 +893,10 @@ static uint8_t usb_hid_poll(usb_device_t *dev) {
 			if (timer_check(iface->qLastPollTime, iface->interval)) { // poll at requested rate
 			//      hid_debugf("poll %d...", iface->ep.epAddr);
 				uint16_t read = iface->ep.maxPktSize;
-				uint8_t buf[iface->ep.maxPktSize];
+				// report may not fit into one packet
+				if (iface->conf.report_size > read)
+					read = iface->conf.report_size;
+				uint8_t buf[read];
 				// clear buffer
 				memset(buf, 0, iface->ep.maxPktSize);
 				uint8_t rcode = usb_in_transfer(dev, &(iface->ep), &read, buf);

--- a/usb/hid.c
+++ b/usb/hid.c
@@ -423,8 +423,15 @@ static uint8_t usb_hid_init(usb_device_t *dev, usb_device_descriptor_t *dev_desc
 			}
 		}
 		rcode = hid_set_idle(dev, info->iface[i].iface_idx, 0, 0);
-		if (rcode && rcode != hrSTALL)
+		if (rcode && rcode != hrSTALL) {
+			hid_debugf("set idle error %d", rcode);
+			if(info->iface[i].device_type == HID_DEVICE_JOYSTICK) {
+				uint8_t c_jindex = joystick_index(info->iface[i].jindex);
+				hid_debugf("releasing joystick #%d, renumbering", c_jindex);
+				joystick_release(c_jindex);
+			}
 			return rcode;
+		}
 
 		// enable boot mode if its not diabled
 		if(info->iface[i].has_boot_mode && !info->iface[i].ignore_boot_mode) {

--- a/usb/hidparser.c
+++ b/usb/hidparser.c
@@ -284,6 +284,7 @@ bool parse_report_descriptor(uint8_t *rep, uint16_t rep_size, hid_report_t *conf
 							return true;
 						else {
 							// retry with next report
+							memset(conf, 0, sizeof(*conf));
 							bit_count = 0;
 							report_complete = 0;
 						}
@@ -362,6 +363,19 @@ bool parse_report_descriptor(uint8_t *rep, uint16_t rep_size, hid_report_t *conf
 					break;
 
 				case 8:
+					// Next report is beginning from this point
+					// If we're already got report descriptor and it's satisfies us - stop further parsing
+					if (conf->report_id) {
+						if(report_is_usable(bit_count, report_complete, conf)) {
+							return true;
+						}
+						else {
+							// reset report items and try with next report
+							memset(conf, 0, sizeof(*conf));
+							bit_count = 0;
+							report_complete = 0;
+						}
+					}
 					hidp_extreme_debugf("REPORT_ID(%d)", value);
 					conf->report_id = value;
 					break;

--- a/usb/hub.c
+++ b/usb/hub.c
@@ -248,6 +248,24 @@ static uint8_t usb_hub_port_status_change(usb_device_t *dev, uint8_t port, hub_e
 
     bResetInitiated = false;
     break;
+
+    // Unhandled event, this shouldn't happen under normal conditions
+  default:
+    iprintf("unexpected status on port %d\n", port);
+    if ((evt.bmChange & USB_HUB_PORT_STATUS_PORT_RESET) && (evt.bmChange & USB_HUB_PORT_STATUS_PORT_CONNECTION)) {
+      // Reconnection happens during reset
+      usb_hub_clear_port_feature(dev, HUB_FEATURE_C_PORT_RESET, port, 0);
+      bResetInitiated = false;
+    }
+    if (evt.bmChange & USB_HUB_PORT_STATUS_PORT_SUSPEND)
+      usb_hub_clear_port_feature(dev, HUB_FEATURE_C_PORT_SUSPEND, port, 0);
+    if (evt.bmChange & USB_HUB_PORT_STATUS_PORT_OVER_CURRENT)
+      usb_hub_clear_port_feature(dev, HUB_FEATURE_C_PORT_OVER_CURRENT, port, 0);
+    if (evt.bmStatus & USB_HUB_PORT_STATUS_PORT_SUSPEND)
+      usb_hub_clear_port_feature(dev, HUB_FEATURE_PORT_SUSPEND, port, 0);
+    if (!(evt.bmStatus & USB_HUB_PORT_STATUS_PORT_POWER))
+      usb_hub_set_port_feature(dev, HUB_FEATURE_PORT_POWER, port, 0);
+    break;
   }
 
   return 0;
@@ -328,4 +346,3 @@ static uint8_t usb_hub_poll(usb_device_t *dev) {
 
 const usb_device_class_config_t usb_hub_class = {
   usb_hub_init, usb_hub_release, usb_hub_poll };  
-

--- a/usb/hub.c
+++ b/usb/hub.c
@@ -210,6 +210,9 @@ static uint8_t usb_hub_port_status_change(usb_device_t *dev, uint8_t port, hub_e
       return 0;
     }
 
+    // Some peripherals may perform a quick reconnection, which causes the disconnect event to be missed.
+    usb_release_device(dev->bAddress, port);
+
     //    timer_delay_msec(100);
 
     iprintf("resetting port %d\n", port);

--- a/usb/usb.c
+++ b/usb/usb.c
@@ -1,4 +1,5 @@
 #include <stdio.h>
+#include <string.h>
 
 #include "timer.h"
 #include "usb.h"
@@ -52,20 +53,16 @@ uint8_t usb_configure(uint8_t parent, uint8_t port, bool lowspeed) {
 	if(i < USB_NUMDEVICES) {
 		iprintf("using free entry at %d\n", i);
 
-		usb_device_t *d = dev+i;
+		usb_device_t *d = &dev[i];
+		memset(d, 0, sizeof(*d));
 
 		// setup generic info
-		d->bAddress = 0;
 		d->parent = parent;
 		d->lowspeed = lowspeed;
 		d->port = port;
-		d->class = NULL;
-		d->vid = d->pid = 0;
 
 		// setup endpoint 0
-		d->ep0.epAddr     = 0;
 		d->ep0.maxPktSize = 8;
-		d->ep0.epAttribs  = 0;
 		d->ep0.bmNakPower = USB_NAK_MAX_POWER;
 
 		if(rcode = usb_get_dev_descr( d, 8, &dev_desc ))

--- a/usb/xboxusb.c
+++ b/usb/xboxusb.c
@@ -229,6 +229,7 @@ static void usb_xbox_read_report(usb_device_t *dev, uint16_t len, uint8_t *buf) 
 	StateJoySetExtra(vjoy>>8, idx);
 	StateJoySetAnalogue(buf[7], buf[9], buf[11], buf[13], idx);
 	StateJoySetRight(jmap, idx);
+	StateJoySetMenu((buf[3] & (1U<<2)), idx);
 
 	// swap joystick 0 and 1 since 1 is the one.
 	// used primarily on most systems (most = Amiga and ST...need to get rid of this)

--- a/usb/xboxusb.h
+++ b/usb/xboxusb.h
@@ -24,13 +24,10 @@
 #ifndef _xboxusb_h_
 #define _xboxusb_h_
 
-/* Data Xbox 360 taken from descriptors */
-#define XBOX_EP_MAXPKTSIZE       32 // max size for data via USB
-
-/* Names we give to the 3 Xbox360 pipes */
-#define XBOX_CONTROL_PIPE    0
-#define XBOX_INPUT_PIPE      1
-#define XBOX_OUTPUT_PIPE     2
+// Data Xbox 360 taken from descriptors
+#define XBOX_INTERFACE_CLASS     0xff
+#define XBOX_INTERFACE_SUBCLASS  0x5D
+#define XBOX_INTERFACE_PROTOCOL  0x01
 
 // PID and VID of the different devices
 #define XBOX_VID                                0x045E // Microsoft Corporation
@@ -57,6 +54,7 @@ typedef struct {
 	uint32_t oldButtons;
 	uint32_t qLastPollTime;  // next poll time
 	ep_t     inEp;
+  ep_t     outEp;
 	uint16_t jindex;
 } usb_xbox_info_t;
 


### PR DESCRIPTION
This PR contains several improvements for USB joysticks. Please let me know if you would prefer to split this PR to more granulated ones.
I tested updated firmware with all USB equipment available to me and didn't found any regressions. 

Below I provide the context for some commits for the history:

**Commit: [hid: fix PSP FuSa gamepad support](https://github.com/mist-devel/mist-firmware/commit/5896ef94af20aae02f16523758fdf46ac8d7350b)**
Firmware v240425 log record with PSP FuSa gamepad connection: [pspfusa_on_v240425.log.txt](https://github.com/user-attachments/files/17083496/pspfusa_on_v240425.log.txt)
Wireshark USB traffic capture: [pspfusa_on_windows.pcapng.zip](https://github.com/user-attachments/files/17083493/pspfusa_on_windows.pcapng.zip)
Issue of PSP FuSa gamepad is that its report size actually bigger than wMaxPacketSize.

**Commit: [usb: fix Redragon Saturn gamepad support](https://github.com/mist-devel/mist-firmware/commit/fed5a2c7559fd42b322a3ad3a8d940cebfaf339e)**
Firmware v240425 log record with Redragon Saturn gamepad connection: 
[redragon_saturn_xinput_mode_on_v240425.log.txt](https://github.com/user-attachments/files/17083502/redragon_saturn_xinput_mode_on_v240425.log.txt)
Issue of this gamepad is that it's perform reconnect (using other VID:PID) during initial enumeration, which causes race conditions within firmware and one gamepad detected as two ones - one of which is dead entry.

**Commit: [usb: fix hub stuck under some conditions](https://github.com/mist-devel/mist-firmware/commit/521e9c1ff1ce2b3aabd41214e22f356d55303986)**
Firmware v240425 log record: [hub_port_hang_v240405.log.txt](https://github.com/user-attachments/files/17083566/hub_port_hang_v240405.log.txt)
New firmware log record: [hub_port_hang_after_fix.log.txt](https://github.com/user-attachments/files/17083567/hub_port_hang_after_fix.log.txt)
Detailed description of this issue within commit message.

**Commit: [xboxusb: fix incorrect joysticks indexing](https://github.com/mist-devel/mist-firmware/commit/0405f16a77682681fc8928552b6f41394b206387)**
Issue demonstration in video:

https://github.com/user-attachments/assets/1ec3d7b3-59f9-4831-9950-cfabf8c77e86


**Commit: [hid: support for devices with multiple reports within one collection](https://github.com/mist-devel/mist-firmware/commit/6c35495de33d4bd943c23cdc43905eefe9257033)**
Firmware log with 8BitDo M30 (in MacOS mode) connection: [8bitdo_macos_mode.log.txt](https://github.com/user-attachments/files/17083599/8bitdo_macos_mode.log.txt)
Parsed HID report for 8BitDo M30 (in MacOS mode): [8bitdo_macos_mode.hid_report.txt](https://github.com/user-attachments/files/17083609/8bitdo_macos_mode.hid_report.txt)
Issue there is that current firmware incorrectly handle HID descriptor with multiple report descriptors if they are within one collection.

**Commit: [xboxusb: add support for 8BitDo USB Wireless Adapter 2](https://github.com/mist-devel/mist-firmware/commit/7f336e77289485075945aeaf943f5294ea20bc7a)**
Issue there is that such adapter require any correct command to be send to it to finish initialization. Otherwise it still reconnecting every few seconds flipping mode (xinput, hid, switch) every time. To accomplish this we need to parse configuration/endpoint descriptors to determine output endpoint address.

Please let me know if you need any additional information.
