### PR TITLE
Added two new Amiga keyboard modes for old keyboard with no GUI keys.

### DIFF
--- a/mist_cfg.c
+++ b/mist_cfg.c
@@ -124,7 +124,7 @@ const ini_var_t mist_ini_vars[] = {
   {"JOY_KEY_MAP", (void*)joystick_key_map, CUSTOM_HANDLER, 0, 0, 1},
 #endif
   {"ROM", (void*)ini_rom_upload, CUSTOM_HANDLER, 0, 0, 1},
-  {"AMIGA_MOD_KEYS", (void*)(&(mist_cfg.amiga_mod_keys)), UINT8, 0, 1, 1},
+  {"AMIGA_MOD_KEYS", (void*)(&(mist_cfg.amiga_mod_keys)), UINT8, 0, 3, 1},
   {"USB_STORAGE", (void*)(&(mist_cfg.usb_storage)), UINT8, 0, 1, 1},
   // [MINIMIG_CONFIG]
   {"KICK1X_MEMORY_DETECTION_PATCH", (void*)(&(minimig_cfg.kick1x_memory_detection_patch)), UINT8, 0, 1, 2},


### PR DESCRIPTION
I have a collection of vintage keyboards which I would like to use with the Minimig core via a suitable USB adapter. What these keyboards all have in common is that they lack Windows keys, without which the core isn't currently usable.

This patch adds two new "amiga_mod_keys" modes, which map Ctrl and Alt to Amiga and Alt (in mode 2) or Ctrl and Alt to Alt and Amiga (i.e. reversed, like the existing mode 1)

In both modes, the Caps Lock key becomes the Ctrl key, but if it's pressed and released with no other key events happening in between, it reverts to being Caps Lock. (In other words, it has "mod-tap".)