### PR TITLE
fix incorrect joystick numbering when joystick_disable_swap=1

### DIFF
--- a/user_io.c
+++ b/user_io.c
@@ -734,7 +734,7 @@ static uint8_t joystick_renumber(uint8_t j) {
 		// if one usb joystick is present, then physical joystick 1 (joystick port)
 		// becomes physical joystick 0 (mouse) port. If more than 1 usb joystick
 		// is present it becomes 2,3,...
-		if(usb_sticks == 1) j = 0;
+		if(usb_sticks == 1) j = mist_cfg.joystick_disable_swap? 1 : 0;
 		else                j = usb_sticks;
 	}
 


### PR DESCRIPTION
With joystick_disable_swap=1 and 1x USB joystick connected - both usb and DB9 (port 2) enumerated as first joystick. I'm not sure about purpose of all this cryptic logic in joystick_renumber(), but hope this little fix shouldn't break anything.