### PR TITLE
usb: fix possible hang during parsing malformed device descriptor

### DIFF
--- a/usb/asix.c
+++ b/usb/asix.c
@@ -323,6 +323,7 @@ static uint8_t asix_parse_conf(usb_device_t *dev, uint8_t conf, uint16_t len) {
     }
     
     // advance to next descriptor
+    if (!p->conf_desc.bLength || p->conf_desc.bLength > len) break;
     len -= p->conf_desc.bLength;
     p = (union buf_u*)(p->raw + p->conf_desc.bLength);
   }

--- a/usb/pl2303.c
+++ b/usb/pl2303.c
@@ -245,6 +245,7 @@ static uint8_t pl2303_parse_conf0(usb_device_t *dev, uint16_t len) {
     }
     
     // advance to next descriptor
+    if (!p->conf_desc.bLength || p->conf_desc.bLength > len) break;
     len -= p->conf_desc.bLength;
     p = (union buf_u*)(p->raw + p->conf_desc.bLength);
   }

--- a/usb/xboxusb.c
+++ b/usb/xboxusb.c
@@ -98,6 +98,7 @@ static uint8_t usb_xbox_parse_conf(usb_device_t *dev, uint8_t conf, uint16_t len
 		}
 
 		// advance to next descriptor
+		if (!p->conf_desc.bLength || p->conf_desc.bLength > len) break;
 		len -= p->conf_desc.bLength;
 		p = (union buf_u*)(p->raw + p->conf_desc.bLength);
 	}


### PR DESCRIPTION
Context:
I found one AT91SAM7S256 where usb_get_conf_descr() randomly returns broken descriptor. Replacing MCU by working one (both marked as revision B) on same PCB fixes this issues, so most probably this is the MCU issue.

Good descriptor:
```
0000: 09 02 8b 00 04 01 00 a0 fa 09 04 00 00 02 ff 5d   ..‹.... .......]
0010: 01 00 11 21 10 01 01 25 81 14 03 03 03 04 13 02   ...!...%Ѓ.......
0020: 08 03 03 07 05 81 03 20 00 04 07 05 02 03 20 00   .....Ѓ. ...... .
0030: 08 09 04 01 00 02 ff 5d 03 00 1b 21 00 01 01 01   .......]...!....
0040: 83 40 01 04 20 16 85 00 00 00 00 00 00 16 05 00   ѓ@.. .….........
0050: 00 00 00 00 00 07 05 83 03 20 00 02 07 05 04 03   .......ѓ. ......
0060: 20 00 04 09 04 02 00 01 ff 5d 02 00 09 21 00 01    ........]...!..
0070: 01 22 86 07 00 07 05 86 03 20 00 10 09 04 03 00   ."....... ......
0080: 00 ff fd 13 04 06 41 00 01 01 03                  ......A....
```

Bad descriptor:
```
0000: 09 02 8b 00 04 01 00 a0 fa 09 04 00 00 02 44 00   ..‹.... ......D.
0010: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00   ................
0020: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00   ................
0030: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00   ................
0040: 83 40 01 04 20 16 85 00 00 00 00 00 00 16 05 00   ѓ@.. .….........
0050: 00 00 00 00 00 07 05 83 03 20 00 02 07 05 04 03   .......ѓ. ......
0060: 20 00 04 09 04 02 00 01 ff 5d 02 00 09 21 00 01    ........]...!..
0070: 01 22 86 07 00 07 05 86 03 20 00 10 09 04 03 00   ."....... ......
0080: 00 ff fd 13 04 06 41 00 01 01 03                  ......A....
```

Bad descriptor (rare variant):
```
0000: 09 02 8b 00 04 01 00 a0 fa 09 04 00 00 02 ff 5d   ..‹.... .......]
0010: 01 00 11 21 10 01 01 25 81 14 03 03 03 04 13 02   ...!...%�.......
0020: 08 03 03 07 05 81 03 20 00 04 07 05 02 03 20 00   .....�. ...... .
0030: 08 44 00 00 00 00 00 00 00 00 00 00 00 00 00 00   .D..............
0040: 83 40 01 04 20 16 85 00 00 00 00 00 00 16 05 00   �@.. .….........
0050: 00 00 00 00 00 07 05 83 03 20 00 02 07 05 04 03   .......�. ......
0060: 20 00 04 09 04 02 00 01 ff 5d 02 00 09 21 00 01    ........]...!..
0070: 01 22 86 07 00 07 05 86 03 20 00 10 09 04 03 00   ."....... ......
0080: 00 ff fd 13 04 06 41 00 01 01 03                  ......A....
```

I hope to delve deeper into usb_get_conf_descr() problem in the future.

This PR fixes hangup when parsing these broken descriptors, which is caused by lack of length checking.