### PR TITLE
data_io ROM processors

### DIFF
--- a/data_io.h
+++ b/data_io.h
@@ -16,15 +16,25 @@
 #define DIO_FILE_RX     0x57
 #define DIO_FILE_RX_DAT 0x58
 
+#define MAX_DATA_IO_PROCESSORS 10
+
+typedef struct {
+    char id[4];
+    void (*file_tx_send)(FIL *file);
+} data_io_processor_t;
+
+void data_io_init();
 void data_io_file_tx_prepare(FIL *file, char index, const char *ext);
 void data_io_set_index(char index);
 void data_io_file_tx_start();
 void data_io_file_tx_done();
 void data_io_fill_tx(unsigned char, unsigned int, char);
 void data_io_file_tx(FIL*, char, const char*);
+void data_io_file_tx_processor(FIL*, char, const char*, const char*);
 void data_io_file_rx(FIL*, char, unsigned int);
 
 // called when a rom entry is found in the mist.ini
 void data_io_rom_upload(char *s, char mode);
 
+char data_io_add_processor(data_io_processor_t *processor);
 #endif // DATA_IO_H

--- a/main.c
+++ b/main.c
@@ -50,6 +50,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "config.h"
 #include "menu.h"
 #include "user_io.h"
+#include "data_io.h"
 #include "arc_file.h"
 #include "font.h"
 #include "tos.h"
@@ -140,6 +141,7 @@ int main(void)
 
     DISKLED_ON;
 
+    data_io_init();
     Timer_Init();
 
     USART_Init(115200);


### PR DESCRIPTION
This change provides the possibility to add custom pluggable processors that can be used to process data before uploading it to the FPGA (uncompress files, process tape files, ...) .It's completely optional and can be enabled in the OSD string by appending a suffix after an 'F' entry like in the following example:

`"F2pACE,ACE,Load ACE;"`

The OSD string is searched for the p entry, and in case it's found registers an special romtype (ROM_PROCESSED) and the required processor id as data_processor_id (ACE in this example).
While uploading the ROM file, in case romtype is ROM_PROCESSED, function data_io_file_tx_processor is used instead, which will try to find the custom processor to handle the file.

New methods data_io_init (to initialize the array of registered plugins) and data_io_add_processor are also added to data_io to handle the plugins.

Usage example can be found in the calypso firmware, basically a plugin consists just on an unique id and a function to upload the file to the fpga:

```
static void uncompress_and_send_ace(FIL *file) {
...
}

data_io_processor_t ACE_PROCESSOR = {
    .id = "ACE",
    .file_tx_send = &uncompress_and_send_ace
};

uint8_t ace_processor_register() {
    return data_io_add_processor(&ACE_PROCESSOR);
}
```

Just calling ace_processor_register should be enough to enable the processor plugin on the firmware.


