### PR TITLE
Serial sink support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ TODAY = `date +"%m/%d/%y"`
 
 PRJ = firmware
 SRC = hw/AT91SAM/Cstartup_SAM7.c hw/AT91SAM/hardware.c hw/AT91SAM/spi.c hw/AT91SAM/mmc.c hw/AT91SAM/at91sam_usb.c hw/AT91SAM/usbdev.c
-SRC += fdd.c  firmware.c  fpga.c hdd.c  main.c  menu.c menu-minimig.c menu-8bit.c osd.c state.c syscalls.c user_io.c settings.c data_io.c boot.c idxfile.c config.c tos.c ikbd.c xmodem.c ini_parser.c cue_parser.c mist_cfg.c archie.c pcecd.c neocd.c snes.c zx_col.c arc_file.c c64files.c font.c utils.c
+SRC += fdd.c  firmware.c  fpga.c hdd.c  main.c  menu.c menu-minimig.c menu-8bit.c osd.c state.c syscalls.c user_io.c settings.c data_io.c boot.c idxfile.c config.c tos.c ikbd.c xmodem.c ini_parser.c cue_parser.c mist_cfg.c archie.c pcecd.c neocd.c snes.c zx_col.c arc_file.c c64files.c font.c utils.c serial_sink.c
 SRC += usb/usb.c usb/max3421e.c usb/usb-max3421e.c usb/usbdebug.c usb/hub.c usb/hid.c usb/hidparser.c usb/xboxusb.c usb/timer.c usb/asix.c usb/pl2303.c usb/usbrtc.c usb/storage.c usb/joymapping.c usb/joystick.c
 SRC += fat_compat.c
 SRC += FatFs/diskio.c FatFs/ff.c FatFs/ffunicode.c

--- a/main.c
+++ b/main.c
@@ -55,6 +55,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "snes.h"
 #include "zx_col.h"
 #include "arc_file.h"
+#include "serial_sink.h"
 #include "font.h"
 #include "tos.h"
 #include "usb.h"
@@ -148,6 +149,7 @@ int main(void)
     c64files_init();
     snes_init();
     zx_init();
+    serial_sink_init();
     Timer_Init();
 
     USART_Init(115200);

--- a/serial_sink.c
+++ b/serial_sink.c
@@ -1,0 +1,49 @@
+/*
+ * serial_sink.c
+ *
+ */
+
+#include "serial_sink.h"
+
+static serial_sink_t* SINKS[NUM_SINKS];
+
+void console_start() {
+  iprintf("\033[1;36m");
+}
+
+void console_end() {
+  iprintf("\033[0m");
+}
+
+void console_echo(uint8_t value) {
+  if (value != 0xff && value != 0x00) {
+    iprintf("%c", value); 
+  }
+}
+
+static serial_sink_t console_sink = {0, 8, 
+     &console_start,
+     &console_echo,
+     &console_end
+};
+
+void serial_sink_init() {
+  memset(SINKS, 0, sizeof(SINKS));
+  serial_sink_register(&console_sink);
+}
+
+bool serial_sink_register(serial_sink_t *sink) {
+  if (sink && sink->index < NUM_SINKS) {
+    if (!SINKS[sink->index]) {
+      SINKS[sink->index] = sink;
+      return true;
+    } else {
+      iprintf("Trying to overwrite serial sink with index %d\n", sink->index);
+    }
+  }
+  return false;
+}
+
+serial_sink_t *serial_sink_get(uint8_t index) {
+  return SINKS[index];
+}

--- a/serial_sink.h
+++ b/serial_sink.h
@@ -1,0 +1,26 @@
+/*
+ * serial_sink.h
+ * 
+ */
+
+#ifndef SERIAL_SINK_H
+#define SERIAL_SINK_H
+
+#include <inttypes.h>
+#include <stdbool.h>
+
+#define NUM_SINKS       8
+
+typedef struct {
+  uint8_t index;
+  uint8_t burst;
+  void (*begin)(void);
+  void (*process_data)(uint8_t data);
+  void (*end)(void);
+} serial_sink_t;
+
+void serial_sink_init();
+bool serial_sink_register(serial_sink_t *sink);
+serial_sink_t *serial_sink_get(uint8_t index);
+
+#endif /* SERIAL_SINK_H */


### PR DESCRIPTION
This CR  allows to change the purpose of the serial data coming from user_io in 8 bit cores. 
The usecase is that I am using the serial stream to pass MIDI data to the [calypso](https://github.com/teiram/calypso-firmware/) MCU, process it there and generate a i2s stream back to the FPGA to be mixed-up with the core audio.

The serial status byte will carry not only information about data availability but also a 3 bit channel number, so that the firmware can decide how to route the data. This is modeled as an array of serial_sink_t pointers, where the index 0 is provided by default and implements the original console behavior. 
Each serial_sink_t element defines:
- The fixed index where it expects to receive data.
- The burst size it allows
- A start function to execute before a received set of data (used in the console_sink to send some escape chars)
- A function to process the incoming bytes
- A end function to execute after no more data is available (or the burst size is reached).

There will be a counterpart pull request for mist-modules, just to set the serial channel in user_io. Initially I don't consider to have multiple purposes for the serial stream on the same core, so I will be using a parameter to set the serial channel. 