### PR TITLE
Info menu support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ TODAY = `date +"%m/%d/%y"`
 
 PRJ = firmware
 SRC = hw/AT91SAM/Cstartup_SAM7.c hw/AT91SAM/hardware.c hw/AT91SAM/spi.c hw/AT91SAM/mmc.c hw/AT91SAM/at91sam_usb.c hw/AT91SAM/usbdev.c
-SRC += fdd.c firmware.c fpga.c hdd.c main.c menu.c menu-minimig.c menu-8bit.c osd.c state.c syscalls.c user_io.c settings.c data_io.c boot.c idxfile.c config.c tos.c ikbd.c xmodem.c ini_parser.c cue_parser.c mist_cfg.c archie.c pcecd.c neocd.c snes.c zx_col.c arc_file.c c64files.c font.c utils.c serial_sink.c
+SRC += fdd.c firmware.c fpga.c hdd.c main.c menu.c menu-minimig.c menu-8bit.c menu_info.c osd.c state.c syscalls.c user_io.c settings.c data_io.c boot.c idxfile.c config.c tos.c ikbd.c xmodem.c ini_parser.c cue_parser.c mist_cfg.c archie.c pcecd.c neocd.c snes.c zx_col.c arc_file.c c64files.c font.c utils.c serial_sink.c
 SRC += usb/usb.c usb/max3421e.c usb/usb-max3421e.c usb/usbdebug.c usb/hub.c usb/hid.c usb/hidparser.c usb/xboxusb.c usb/timer.c usb/asix.c usb/pl2303.c usb/storage.c usb/joymapping.c usb/joystick.c
 SRC += usb/rtc.c usb/rtc/i2c-tiny.c usb/rtc/i2c-mcp2221.c usb/rtc/pcf85263.c usb/rtc/ds3231.c
 SRC += fat_compat.c

--- a/menu-8bit.c
+++ b/menu-8bit.c
@@ -29,6 +29,7 @@
 #include "hdd.h"
 #include "fat_compat.h"
 #include "cue_parser.h"
+#include "menu_info.h"
 
 extern char s[FF_LFN_BUF + 1];
 
@@ -455,6 +456,13 @@ static char GetMenuItem_8bit(uint8_t idx, char action, menu_item_t *item) {
 	return 1;
 }
 
+static char KeyEvent_8bit(uint8_t key) {
+	if (key == KEY_F1) {
+		menu_info_open(user_io_get_core_name());
+	}
+	return 0;
+}
+
 void Setup8bitMenu() {
 	char *c, *p;
 	int i;
@@ -483,5 +491,6 @@ void Setup8bitMenu() {
 	strcat(helptext_custom, helptexts[HELPTEXT_MAIN]);
 	helptext=helptext_custom;
 
-	SetupMenu(GetMenuPage_8bit, GetMenuItem_8bit, NULL);
+	iprintf("Setting up 8bit menu\n");
+	SetupMenu(GetMenuPage_8bit, GetMenuItem_8bit, KeyEvent_8bit);
 }

--- a/menu_info.c
+++ b/menu_info.c
@@ -1,0 +1,149 @@
+/*
+  This file is part of MiST-firmware
+
+  MiST-firmware is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 3 of the License, or
+  (at your option) any later version.
+
+  MiST-firmware is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <stdlib.h>
+#include <string.h>
+
+#include "menu_info.h"
+#include "fat_compat.h"
+#include "menu.h"
+#include "osd.h"
+#include "debug.h"
+
+#define CHAR_IS_EOL(c)      (((c) == '\n'))
+
+#define LINE_SIZE 29
+#define PAGE_SIZE 512
+
+static const char* SUFFIX = ".info";
+
+static FIL infofile;
+static int16_t last_idx = -1;
+static char line[LINE_SIZE];
+static int curr_page = -1;
+static int curr_page_pos = 0;
+static int curr_file_size = -1;
+
+static char nextchar()
+{
+	UINT br;
+	if (curr_file_size < 0) {
+		curr_file_size = (int) f_size(&infofile);
+	}
+	if (curr_page < 0 || curr_page_pos == PAGE_SIZE) {
+		curr_page++;
+		if ((curr_page * PAGE_SIZE) < curr_file_size) {
+			menu_debugf("Seeking to %d. File size: %d\n", curr_page * PAGE_SIZE, curr_file_size);
+			if (f_lseek(&infofile, curr_page * PAGE_SIZE) == FR_OK) {
+				menu_debugf("Reading buffer\n");
+				f_read(&infofile, sector_buffer, PAGE_SIZE, &br);
+				curr_page_pos = 0;
+				sector_buffer[br] = 0;
+			} else {
+				return 0;
+			}
+		} else {
+			return 0;
+		}
+	}
+	return sector_buffer[curr_page_pos++];
+}
+
+static char *nextline()
+{
+	int pos = 0;
+	while (pos < LINE_SIZE) {
+		char v = nextchar();
+		if (!v || CHAR_IS_EOL(v)) {
+			break;
+		} else {
+			line[pos++] = v;
+		}
+	}
+	line[pos] = 0;
+	menu_debugf("Pos: %d, Line: %s\n", pos, line);
+	return line;
+}
+
+static char* infoline(uint8_t idx)
+{
+	int pos = 0;
+	char *p;
+	int from;
+	if (idx != last_idx + 1) {
+		//Restart
+		menu_debugf("Restart on %d != %d!!\n", idx, last_idx + 1);
+		curr_page = -1;
+		from = 0;
+	} else {
+		from = last_idx + 1;
+	}
+	while (from++ <= idx && (p = nextline()));
+	last_idx = idx;
+	return p;
+}
+
+
+static char getmenuitem(uint8_t idx, char action, menu_item_t *item)
+{
+	char *str;
+	if (action == MENU_ACT_GET) {
+		menu_debugf("getmenuitem %d\n", idx);
+		str = infoline(idx);
+		item->item = str;
+		item->active = (str[0] != 0);
+		return item->active;
+	} else {
+		return 0;
+	}
+}
+
+static char getmenupage(uint8_t idx, char action, menu_page_t *page) 
+{
+	if (action == MENU_PAGE_EXIT) {
+		f_close(&infofile);
+		curr_page = -1;
+		curr_file_size = -1;
+		last_idx = -1;
+		return 0;
+	}
+
+	page->title = "INFO";
+	page->flags = 0;
+	page->timer = 0;
+	page->stdexit = MENU_STD_EXIT;
+	return 0;
+}
+
+void menu_info_open(const char *core_id)
+{
+	menu_debugf("menu_info_open: %s\n", core_id);
+	if (core_id && core_id[0]) {
+		int core_namelen = strlen(core_id);
+		char info_filename[core_namelen + strlen(SUFFIX) + 1];
+		info_filename[0] = 0;
+		strcat(info_filename, "/");
+		strcat(info_filename, core_id);
+		strcat(info_filename, SUFFIX);
+		menu_debugf("Info file to look for: '%s'\n", info_filename);
+		if (f_open(&infofile, info_filename, FA_READ) == FR_OK) {
+			SetupMenu(&getmenupage, &getmenuitem, NULL);
+		} else {
+			iprintf("Unable to open info file %s\n", info_filename);
+		}
+	}
+}

--- a/menu_info.h
+++ b/menu_info.h
@@ -1,0 +1,23 @@
+/*
+  This file is part of MiST-firmware
+
+  MiST-firmware is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 3 of the License, or
+  (at your option) any later version.
+
+  MiST-firmware is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef MENU_INFO_H
+#define MENU_INFO_H
+
+void menu_info_open(const char *core_id);
+
+#endif // MENU_INFO_H


### PR DESCRIPTION
This PR provides an info  menu that can be invoked pressing F1 while the OSD of an 8 bit core is open and if there is a text file named after the core id with extension .info in the SD card.
I found it interesting to deliver information about the core, like relevant key mapping or supported features as well as basic information about the core.
