### PR TITLE
Allow to stick/unstick a menu

### DIFF
--- a/menu-8bit.c
+++ b/menu-8bit.c
@@ -463,6 +463,18 @@ static char KeyEvent_8bit(uint8_t key) {
 	return 0;
 }
 
+static const menu_handler_t NO_MENU_HANDLER = {NULL, NULL, NULL};
+
+static menu_handler_t sticky_menu_handler = NO_MENU_HANDLER;
+
+void set_sticky_menu_handler(menu_handler_t handler) {
+  sticky_menu_handler = handler;
+}
+
+void clear_sticky_menu_handler() {
+  sticky_menu_handler = NO_MENU_HANDLER;
+}
+
 void Setup8bitMenu() {
 	char *c, *p;
 	int i;
@@ -491,6 +503,11 @@ void Setup8bitMenu() {
 	strcat(helptext_custom, helptexts[HELPTEXT_MAIN]);
 	helptext=helptext_custom;
 
-	iprintf("Setting up 8bit menu\n");
-	SetupMenu(GetMenuPage_8bit, GetMenuItem_8bit, KeyEvent_8bit);
+	if (sticky_menu_handler.page_handler != NULL && sticky_menu_handler.items_handler != NULL) {
+		iprintf("Setting up sticky menu\n");
+		SetupMenu(sticky_menu_handler.page_handler, sticky_menu_handler.items_handler, sticky_menu_handler.key_handler);
+	} else {
+		iprintf("Setting up 8bit menu\n");
+		SetupMenu(GetMenuPage_8bit, GetMenuItem_8bit, KeyEvent_8bit);
+	}
 }

--- a/menu-8bit.h
+++ b/menu-8bit.h
@@ -18,6 +18,18 @@
 #ifndef MENU_8BIT_H
 #define MENU_8BIT_H
 
+#include "menu.h"
+
+typedef struct {
+  menu_get_page_t page_handler;
+  menu_get_items_t items_handler;
+  menu_key_event_t key_handler;
+} menu_handler_t;
+
+void set_sticky_menu_handler(menu_handler_t handler);
+
+void clear_sticky_menu_handler();
+
 void Setup8bitMenu();
 
 #endif


### PR DESCRIPTION
This PR adds the possibility to stick a menu, providing somehow hide/show semantics to the 8 bit menu without losing state. 
The usecase would be stateful firmware features, like for instance an embedded tape player, but allowing the user to hide the OSD temporarily and come back to the previous state. 
I'm using this to implement a tape player for the board calypso, so that when the OSD is hidden and shown again, the player OSD is still there. The user has to explicitly close the player to gain access to the root menu again.

