### PR TITLE
Menu Page plugins

### DIFF
--- a/main.c
+++ b/main.c
@@ -146,6 +146,7 @@ int main(void)
     DISKLED_ON;
 
     data_io_init();
+    page_plugin_init();
     c64files_init();
     snes_init();
     zx_init();

--- a/menu-8bit.h
+++ b/menu-8bit.h
@@ -18,6 +18,17 @@
 #ifndef MENU_8BIT_H
 #define MENU_8BIT_H
 
+#define MAX_PAGE_PLUGINS 10
+
+typedef struct {
+    char id[4];
+    void (*init_menu)(const char *arg1, const char *arg2);
+} menu_page_plugin_t;
+
+void page_plugin_init();
+char page_plugin_add(menu_page_plugin_t *plugin);
+
+
 void Setup8bitMenu();
 
 #endif


### PR DESCRIPTION
As discussed in this previous [PR](https://github.com/mist-devel/mist-firmware/pull/139)
this new PR adds the possibility to define menu plugins to render custom menus for embedded applications/utilities that are part of the firmware in a modular way.
The usage in the OSD would be something like:

` P<n>p<HND>,<arg1>,<arg2>,<Text>;`

where:
- n is an unused page number
- HND is the unique identifier for the menu handler
- arg1, arg2: Arguments to pass to the menu handler
- Text. Text to show in the menu.

Example:
> P3pTAP,TAP,C64,Tape Player;

In this case, arg1 and arg2 are used to inform the plugin about the format/extension and the machine or machine type it should support, but each plugin can use them (or ignore) at will.
